### PR TITLE
Unix style line endings by default

### DIFF
--- a/models/JSONPrettyPrint.cfc
+++ b/models/JSONPrettyPrint.cfc
@@ -15,7 +15,7 @@ component accessors="true" singleton alias='JSONPrettyPrint' {
 	 * @lineEnding String to use for line endings.  Defaults to CRLF.
 	 * @spaceAfterColon Add space after each colon like "value": true instead of"value":true 
  	 **/
-	public function formatJson( json, indent='    ', lineEnding=chr( 13 ) & chr( 10 ), boolean spaceAfterColon=false ) {
+	public function formatJson( json, indent='    ', lineEnding=chr( 10 ), boolean spaceAfterColon=false ) {
 		
 		// Overload this method to accept a struct or array
 		if( !isSimpleValue( arguments.json ) ) {


### PR DESCRIPTION
Change default line endings to Unix style. That way files being written with content formatted by this utility will be compatible with GIT (windows style line endings make any change to a file appears as an entire file replacement to the git diff)