### PR TITLE
Encode object keys correctly when using CFML printer

### DIFF
--- a/models/CFMLPrinter.cfc
+++ b/models/CFMLPrinter.cfc
@@ -52,7 +52,8 @@ component accessors="true" {
             }
             var strs = [ ];
             for ( var key in keys ) {
-                var str = baseIndent & settings.indent & ( settings.ansi ? ANSIPrint.wrap( '"#key#"', 'key', settings.ansiColors ) : '"#key#"' ) & settings.colon;
+                var jsonKey = serializeJSON( key );
+                var str = baseIndent & settings.indent & ( settings.ansi ? ANSIPrint.wrap( jsonKey, 'key', settings.ansiColors ) : jsonKey ) & settings.colon;
                 if ( !structKeyExists( json, key ) || isNull( json[ key ] ) ) {
                     str &= settings.ansi ? ANSIPrint.wrap( 'null', 'value', settings.ansiColors ) : 'null';
                 } else {

--- a/tests/specs/unit/JSONPrettyPrintSpec.cfc
+++ b/tests/specs/unit/JSONPrettyPrintSpec.cfc
@@ -60,6 +60,16 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( isJSON( formatted ) ).toBeTrue();
             } );
 
+            it( 'correctly escapes object keys with both printers', function() {
+                var JSONPrettyPrint = getInstance( 'JSONPrettyPrint' );
+                var srcJSON = '{"a\\b":1}';
+
+                var formatted = JSONPrettyPrint.getCFMLPrinter().formatJson( json = srcJSON, indent = '', lineEnding = '' );
+                expect( formatted ).toBe( '{"a\\b":1}' );
+                formatted = JSONPrettyPrint.getJSONPrinter().formatJson( json = srcJSON, indent = '', lineEnding = '' );
+                expect( formatted ).toBe( '{"a\\b":1}' );
+            } );
+
             it( 'supports formatting queries', function() {
                 var testQuery = queryNew( 'id', 'integer', [ [ 1 ], [ 2 ], [ 3 ] ] );
                 var obj = { 'testQuery': testQuery };


### PR DESCRIPTION
Fix for JSON object keys that need to have characters escaped when formatting using the CFML Printer.